### PR TITLE
Change bit range from 64-127 to 32-127

### DIFF
--- a/docs/instruction/sqrtss.md
+++ b/docs/instruction/sqrtss.md
@@ -18,7 +18,7 @@ The source operand can be an XMM register or a 32-bit memory location. The desti
  
 ```c
 Destination[0..31] = SquareRoot(Source[0..31]);
-//Destination[64..127] remains unchanged
+//Destination[32..127] remains unchanged
 
 ```
  


### PR DESCRIPTION
Thanks for the amazing x86 docs!

I noticed a potential issue when reading over the `sqrtss` instruction.
I believe that bits from 32-127 get copied from the source register to the destination.

![image](https://github.com/user-attachments/assets/176b1198-4451-4a0d-943f-babc36b7607a)
"upper single precision floating-point values (bits[127:32]) from xmm2 are copied to xmm1[127:32]."